### PR TITLE
Update usage doc to reflect limitations

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -215,7 +215,7 @@ messages and publish messages.
 
 
     if __name__ == '__main__':
-        socketio.run(app, host='0.0.0.0', port=5000, use_reloader=True, debug=True)
+        socketio.run(app, host='0.0.0.0', port=5000, use_reloader=False, debug=True)
 
 
 .. _Flask application object: http://flask.pocoo.org/docs/0.12/api/#application-object


### PR DESCRIPTION
The limitations on the main page talk about not using the reloader but
the usage example enables the reloader, this patch simply updates the
exmaple to reflect the limitation.