### PR TITLE
Removed unnecessary boostrap module from example app

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -158,7 +158,6 @@ messages and publish messages.
     from flask import Flask, render_template
     from flask_mqtt import Mqtt
     from flask_socketio import SocketIO
-    from flask_bootstrap import Bootstrap
 
     eventlet.monkey_patch()
 
@@ -180,7 +179,6 @@ messages and publish messages.
 
     mqtt = Mqtt(app)
     socketio = SocketIO(app)
-    bootstrap = Bootstrap(app)
 
 
     @app.route('/')


### PR DESCRIPTION
Since boostrap is not required for a small test application, it would be more concise and potentially less confusing if it were removed from the documentation.

It would also be very nice to include a simple `index.html` file to go with the example in the documentation. I will submit another pull request for that.