### PR TITLE
Add unsubscribe_all handler to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,11 @@ def handle_subscribe(json_str):
     mqtt.subscribe(data['topic'])
 
 
+@socketio.on('unsubscribe_all')
+def handle_unsubscribe_all():
+    mqtt.unsubscribe_all()
+
+
 @mqtt.on_message()
 def handle_mqtt_message(client, userdata, message):
     data = dict(

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -198,6 +198,11 @@ messages and publish messages.
     def handle_subscribe(json_str):
         data = json.loads(json_str)
         mqtt.subscribe(data['topic'])
+    
+    
+    @socketio.on('unsubscribe_all')
+    def handle_unsubscribe_all():
+        mqtt.unsubscribe_all()
 
 
     @mqtt.on_message()

--- a/example/app.py
+++ b/example/app.py
@@ -55,6 +55,11 @@ def handle_subscribe(json_str):
     mqtt.subscribe(data['topic'], data['qos'])
 
 
+@socketio.on('unsubscribe_all')
+def handle_unsubscribe_all():
+    mqtt.unsubscribe_all()
+
+
 @mqtt.on_message()
 def handle_mqtt_message(client, userdata, message):
     data = dict(


### PR DESCRIPTION
In the `index.html` there is a SocketIO call for `unsubscribe_all` 
but it is not handled in the App.The resultant behaviour 
is that, upon clicking the unsubscribe button, the data 
still keeps coming in.
This commit adds the handler for unsubscribing to all topics