### PR TITLE
support setting whether to clean the session

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ app.config['MQTT_USERNAME'] = ''
 app.config['MQTT_PASSWORD'] = ''
 app.config['MQTT_KEEPALIVE'] = 5
 app.config['MQTT_TLS_ENABLED'] = False
+app.config['MQTT_CLEAN_SESSION'] = True
 
 # Parameters for SSL enabled
 # app.config['MQTT_BROKER_PORT'] = 8883

--- a/example/app.py
+++ b/example/app.py
@@ -19,6 +19,7 @@ app.config['TEMPLATES_AUTO_RELOAD'] = True
 app.config['MQTT_BROKER_URL'] = 'broker.hivemq.com'
 app.config['MQTT_BROKER_PORT'] = 1883
 app.config['MQTT_CLIENT_ID'] = 'flask_mqtt'
+app.config['MQTT_CLEAN_SESSION'] = True
 app.config['MQTT_USERNAME'] = ''
 app.config['MQTT_PASSWORD'] = ''
 app.config['MQTT_KEEPALIVE'] = 5

--- a/flask_mqtt/__init__.py
+++ b/flask_mqtt/__init__.py
@@ -88,19 +88,14 @@ class Mqtt():
         # type: (Flask) -> None
         """Init the Flask-MQTT addon."""
         self.client_id = app.config.get("MQTT_CLIENT_ID", "")
+        self.clean_session = app.config.get("MQTT_CLEAN_SESSION", True)
 
         if isinstance(self.client_id, unicode):
             self.client._client_id = self.client_id.encode('utf-8')
         else:
             self.client._client_id = self.client_id
 
-        self.clean_session = app.config.get("MQTT_CLEAN_SESSION", True)
-        if not isinstance(self.clean_session, bool):
-            raise TypeError('clean session must be a boolean type.')
-        if not self.clean_session and (self.client_id == "" or self.client_id is None):
-            raise ValueError('A client id must be provided if clean session is False.')
         self.client._clean_session = self.clean_session
-
         self.client._transport = app.config.get("MQTT_TRANSPORT", "tcp").lower()
         self.client._protocol = app.config.get("MQTT_PROTOCOL_VERSION", MQTTv311)
 

--- a/flask_mqtt/__init__.py
+++ b/flask_mqtt/__init__.py
@@ -94,6 +94,13 @@ class Mqtt():
         else:
             self.client._client_id = self.client_id
 
+        self.clean_session = app.config.get("MQTT_CLEAN_SESSION", True)
+        if not isinstance(self.clean_session, bool):
+            raise TypeError('clean session must be a boolean type.')
+        if not self.clean_session and (self.client_id == "" or self.client_id is None):
+            raise ValueError('A client id must be provided if clean session is False.')
+        self.client._clean_session = self.clean_session
+
         self.client._transport = app.config.get("MQTT_TRANSPORT", "tcp").lower()
         self.client._protocol = app.config.get("MQTT_PROTOCOL_VERSION", MQTTv311)
 

--- a/tests/test_flaskmqtt.py
+++ b/tests/test_flaskmqtt.py
@@ -42,6 +42,7 @@ class FlaskMQTTTestCase(unittest.TestCase):
         self.app.config['MQTT_BROKER_URL'] = 'broker_url'
         self.app.config['MQTT_BROKER_PORT'] = 'broker_port'
         self.app.config['MQTT_TLS_ENABLED'] = 'tls_enabled'
+        self.app.config['MQTT_CLEAN_SESSION'] = True
         self.app.config['MQTT_KEEPALIVE'] = 'keepalive'
         self.app.config['MQTT_LAST_WILL_TOPIC'] = 'home/lastwill'
         self.app.config['MQTT_LAST_WILL_MESSAGE'] = 'last will'
@@ -62,6 +63,7 @@ class FlaskMQTTTestCase(unittest.TestCase):
         self.assertEqual('broker_url', mqtt.broker_url)
         self.assertEqual('broker_port', mqtt.broker_port)
         self.assertEqual('tls_enabled', mqtt.tls_enabled)
+        self.assertEqual(True, mqtt.clean_session)
         self.assertEqual('keepalive', mqtt.keepalive)
         self.assertEqual('home/lastwill', mqtt.last_will_topic)
         self.assertEqual('last will', mqtt.last_will_message)


### PR DESCRIPTION
In order to solve the problem of subscribers losing messages in a specific scenario.

For example, when the subscribing client disconnects from the broker abnormally, the subscribing client tries to re-establish the connection, but the message sent by the producer before the connection is successfully established is not received by the subscriber.

Setting clean_session is False could solve the problem.