### PR TITLE
fix dependency for python >= 3.5

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 1.0.6 [Unreleased]
+--------------------------
+* Do not install typing when using Python >= 3.5
+  [cekk]
+
 Version 1.0.5
 -------------
 * fix issue #40. One can now use the @mqtt decorators before calling `mqtt.init_app()`

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ else:
         platforms='any',
         install_requires=[
             'Flask',
-            'typing',
+            'typing;python_version<"3.5"',
             'paho-mqtt'
         ],
         classifiers=[


### PR DESCRIPTION
typing is in standard library since Python 3.5, so this is not needed anymore