### PR TITLE
init_app now sets app member for Mqtt

### DIFF
--- a/flask_mqtt/__init__.py
+++ b/flask_mqtt/__init__.py
@@ -105,6 +105,7 @@ class Mqtt:
 
     def init_app(self, app: Flask) -> None:
         """Init the Flask-MQTT addon."""
+        self.app = app
         
         if "MQTT_CLIENT_ID" in app.config:
             self.client_id = app.config["MQTT_CLIENT_ID"]


### PR DESCRIPTION
As per comments in the following issue https://github.com/stlehmann/Flask-MQTT/issues/86 , this allows for the app context to be automatically available upon functions being called that are decorated with e.g.

@mqtt.on_message
or
@mqtt.on_topic