### PR TITLE
Issue: Connect to multiple MQTT Servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /app
 RUN pip3 install -e .
 RUN pip3 install pytest coverage pytest-cov
 RUN py3clean .
-CMD mosquitto -d && pytest -v --cov flask_mqtt
+CMD mosquitto -d && mosquitto -p 1885 -d && mosquitto -p 1886 -d && pytest -v --cov flask_mqtt

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Find the documentation on [http://flask-mqtt.readthedocs.io][2].
 * configuration via Flask config variables
 * auto-connect on start of your web application
 * publish and subscribe messages
+* connect to multiple MQTT servers
 * use callbacks for certain topics
 * use one callback for all subscribed topics
 
@@ -121,6 +122,27 @@ To publish a message you can use the `publish()` method.
 
 ```python
 mqtt.publish('home/mytopic', 'this is my message')
+```
+
+### Connect to multiple MQTT Servers
+
+To connect to multiple servers, you can create multiple mqtt clients in your application by specifying the ```config_prefix``` when initializing ```Mqtt()```
+
+```python
+# default mqtt client
+app.config["MQTT_broker_url"] = "example.com"
+app.config["MQTT_broker_port"] = 8883
+mqtt = Mqtt(app)
+
+# create second mqtt client for a different broker 
+app.config["MQTT2_broker_url"] = "example2.com"
+app.config["MQTT_broker_port"] = 1883
+mqtt2 = Mqtt(app, config_prefix="MQTT2")
+
+# create third mqtt client for a different broker 
+app.config["MQTT3_broker_url"] = "example3.com"
+app.config["MQTT3_broker_port"] = 8883
+mqtt3 = Mqtt(app, config_prefix="MQTT3")
 ```
 
 ### Small publish/subscribe MQTT client

--- a/flask_mqtt/__init__.py
+++ b/flask_mqtt/__init__.py
@@ -64,7 +64,7 @@ class Mqtt:
     """
 
     def __init__(
-        self, app: Flask = None, connect_async: bool = False, mqtt_logging: bool = False
+        self, app: Flask = None, connect_async: bool = False, mqtt_logging: bool = False, config_prefix: str = "MQTT"
     ) -> None:
         self._connect_async: bool = connect_async
         self._connect_handler: Optional[Callable] = None
@@ -77,6 +77,7 @@ class Mqtt:
 
         # configuration parameters
         self.client_id: str = ""
+        self.config_prefix = config_prefix
         self.clean_session: bool = True
         self.username: Optional[str] = None
         self.password: Optional[str] = None
@@ -101,12 +102,12 @@ class Mqtt:
             self.client.enable_logger(logger)
 
         if app is not None:
-            self.init_app(app)
+            self.init_app(app, self.config_prefix)
 
-    def init_app(self, app: Flask) -> None:
+    def init_app(self, app: Flask, config_prefix : str = "MQTT") -> None:
         """Init the Flask-MQTT addon."""
         
-        if "MQTT_CLIENT_ID" in app.config:
+        if config_prefix + "_CLIENT_ID" in app.config:
             self.client_id = app.config["MQTT_CLIENT_ID"]
             
         if isinstance(self.client_id, unicode):
@@ -114,63 +115,63 @@ class Mqtt:
         else:
             self.client._client_id = self.client_id
 
-        self.client._transport = app.config.get("MQTT_TRANSPORT", "tcp").lower()
-        self.client._protocol = app.config.get("MQTT_PROTOCOL_VERSION", MQTTv311)
+        self.client._transport = app.config.get(config_prefix + "_TRANSPORT", "tcp").lower()
+        self.client._protocol = app.config.get(config_prefix + "_PROTOCOL_VERSION", MQTTv311)
         self.client._clean_session = self.clean_session
         self.client.on_connect = self._handle_connect
         self.client.on_disconnect = self._handle_disconnect
 
-        if "MQTT_CLEAN_SESSION" in app.config:
-            self.clean_session = app.config["MQTT_CLEAN_SESSION"]
+        if config_prefix + "_CLEAN_SESSION" in app.config:
+            self.clean_session = app.config[config_prefix + "_CLEAN_SESSION"]
 
-        if "MQTT_USERNAME" in app.config:
-            self.username = app.config["MQTT_USERNAME"]
+        if config_prefix + "_USERNAME" in app.config:
+            self.username = app.config[ config_prefix + "_USERNAME"]
 
-        if "MQTT_PASSWORD" in app.config:
-            self.password = app.config["MQTT_PASSWORD"]
+        if config_prefix + "_PASSWORD" in app.config:
+            self.password = app.config[config_prefix + "_PASSWORD"]
 
-        if "MQTT_BROKER_URL" in app.config:
-            self.broker_url = app.config["MQTT_BROKER_URL"]
+        if config_prefix + "_BROKER_URL" in app.config:
+            self.broker_url = app.config[config_prefix + "_BROKER_URL"]
 
-        if "MQTT_BROKER_PORT" in app.config:
-            self.broker_port = app.config["MQTT_BROKER_PORT"]
+        if config_prefix + "_BROKER_PORT" in app.config:
+            self.broker_port = app.config[config_prefix + "_BROKER_PORT"]
 
-        if "MQTT_TLS_ENABLED" in app.config:
-            self.tls_enabled = app.config["MQTT_TLS_ENABLED"]
+        if config_prefix + "_TLS_ENABLED" in app.config:
+            self.tls_enabled = app.config[config_prefix + "_TLS_ENABLED"]
 
-        if "MQTT_KEEPALIVE" in app.config:
-            self.keepalive = app.config["MQTT_KEEPALIVE"]
+        if config_prefix + "_KEEPALIVE" in app.config:
+            self.keepalive = app.config[config_prefix + "_KEEPALIVE"]
 
-        if "MQTT_LAST_WILL_TOPIC" in app.config:
-            self.last_will_topic = app.config["MQTT_LAST_WILL_TOPIC"]
+        if config_prefix + "_LAST_WILL_TOPIC" in app.config:
+            self.last_will_topic = app.config[config_prefix + "_LAST_WILL_TOPIC"]
 
-        if "MQTT_LAST_WILL_MESSAGE" in app.config:
-            self.last_will_message = app.config["MQTT_LAST_WILL_MESSAGE"]
+        if config_prefix + "_LAST_WILL_MESSAGE" in app.config:
+            self.last_will_message = app.config[config_prefix + "_LAST_WILL_MESSAGE"]
 
-        if "MQTT_LAST_WILL_QOS" in app.config:
-            self.last_will_qos = app.config["MQTT_LAST_WILL_QOS"]
+        if config_prefix + "_LAST_WILL_QOS" in app.config:
+            self.last_will_qos = app.config[config_prefix + "_LAST_WILL_QOS"]
 
-        if "MQTT_LAST_WILL_RETAIN" in app.config:
-            self.last_will_retain = app.config["MQTT_LAST_WILL_RETAIN"]
+        if config_prefix + "_LAST_WILL_RETAIN" in app.config:
+            self.last_will_retain = app.config[ config_prefix + "_LAST_WILL_RETAIN"]
 
         if self.tls_enabled:
-            if "MQTT_TLS_CA_CERTS" in app.config:
-                self.tls_ca_certs = app.config["MQTT_TLS_CA_CERTS"]
+            if config_prefix + "_TLS_CA_CERTS" in app.config:
+                self.tls_ca_certs = app.config[config_prefix + "_TLS_CA_CERTS"]
 
-            if "MQTT_TLS_CERTFILE" in app.config:
-                self.tls_certfile = app.config["MQTT_TLS_CERTFILE"]
+            if config_prefix + "_TLS_CERTFILE" in app.config:
+                self.tls_certfile = app.config[config_prefix + "_TLS_CERTFILE"]
 
-            if "MQTT_TLS_KEYFILE" in app.config:
-                self.tls_keyfile = app.config["MQTT_TLS_KEYFILE"]
+            if config_prefix + "_TLS_KEYFILE" in app.config:
+                self.tls_keyfile = app.config[config_prefix + "_TLS_KEYFILE"]
 
-            if "MQTT_TLS_CIPHERS" in app.config:
-                self.tls_ciphers = app.config["MQTT_TLS_CIPHERS"]
+            if config_prefix + "_TLS_CIPHERS" in app.config:
+                self.tls_ciphers = app.config[config_prefix + "_TLS_CIPHERS"]
 
-            if "MQTT_TLS_INSECURE" in app.config:
-                self.tls_insecure = app.config["MQTT_TLS_INSECURE"]
+            if config_prefix + "_TLS_INSECURE" in app.config:
+                self.tls_insecure = app.config[config_prefix + "_TLS_INSECURE"]
 
-            self.tls_cert_reqs = app.config.get("MQTT_TLS_CERT_REQS", ssl.CERT_REQUIRED)
-            self.tls_version = app.config.get("MQTT_TLS_VERSION", ssl.PROTOCOL_TLSv1)
+            self.tls_cert_reqs = app.config.get(config_prefix + "_TLS_CERT_REQS", ssl.CERT_REQUIRED)
+            self.tls_version = app.config.get(config_prefix + "_TLS_VERSION", ssl.PROTOCOL_TLSv1)
 
         # set last will message
         if self.last_will_topic is not None:

--- a/tests/test_multiple_servers.py
+++ b/tests/test_multiple_servers.py
@@ -1,0 +1,377 @@
+import sys
+import unittest
+import time
+from flask import Flask
+
+try:
+    sys.modules.pop('paho.mqtt.client')
+    sys.modules.pop('flask_mqtt')
+except KeyError:
+    pass
+from flask_mqtt import Mqtt, MQTT_ERR_SUCCESS
+
+
+def wait(seconds=0.5):
+    time.sleep(seconds)
+
+
+class FlaskMQTTTestCase(unittest.TestCase):
+    def setUp(self):
+
+        self.app = Flask(__name__)
+        self.app.config['MQTT_USERNAME'] = 'mqtt'
+        self.app.config['MQTT_PASSWORD'] = 'mqtt_server_one'
+        
+        self.app.config['MQTT2_USERNAME'] = 'mqtt2'
+        self.app.config['MQTT2_PASSWORD'] = 'mqtt_server_two'
+        self.app.config['MQTT2_BROKER_PORT'] = 1885
+        
+        self.app.config['MQTT3_USERNAME'] = 'mqtt3'
+        self.app.config['MQTT3_PASSWORD'] = 'mqtt_server_three'
+        self.app.config['MQTT3_BROKER_PORT'] = 1886
+
+    def test_simple_connect(self):
+        self.mqtt = Mqtt(self.app)
+        self.mqtt._disconnect()
+
+    def test_connect_same_config_prefix(self):
+        self.mqtt = Mqtt(self.app)
+        self.assertEqual(self.mqtt.username, 'mqtt')
+        self.assertEqual(self.mqtt.password, 'mqtt_server_one')
+        
+        self.mqtt._disconnect()
+    
+    def test_connect_diff_config_prefix(self):
+        self.mqtt = Mqtt(self.app, config_prefix="MQTT4")
+        self.assertNotEqual(self.mqtt.username, 'mqtt')
+        self.assertNotEqual(self.mqtt.password, 'mqtt_server_one')
+        self.assertEqual(self.mqtt.username, None)
+        self.assertEqual(self.mqtt.password, None)
+        
+        self.mqtt._disconnect()
+    
+    def test_connect_multiple_servers(self):
+        self.mqtt = Mqtt(self.app, config_prefix="MQTT")
+        self.mqtt2 = Mqtt(self.app, config_prefix="MQTT2")
+        self.mqtt3 = Mqtt(self.app, config_prefix="MQTT3")
+        
+        self.assertEqual('mqtt', self.mqtt.username)
+        self.assertEqual('mqtt2', self.mqtt2.username)
+        self.assertEqual('mqtt3', self.mqtt3.username)
+        self.assertEqual(1883, self.mqtt.broker_port)
+        self.assertEqual(1885, self.mqtt2.broker_port)
+        self.assertEqual(1886, self.mqtt3.broker_port)
+        
+        self.mqtt._disconnect()
+        self.mqtt2._disconnect()
+        self.mqtt3._disconnect()
+    
+    def test_subscribe_multiple_servers(self):
+        self.subscribe_handled_mqtt = False
+        self.unsubscribe_handled_mqtt = False
+        self.subscribe_handled_mqtt2 = False
+        self.unsubscribe_handled_mqtt2 = False
+        self.subscribe_handled_mqtt3 = False
+        self.unsubscribe_handled_mqtt3 = False
+        
+        self.mqtt = Mqtt(self.app, config_prefix="MQTT")
+        self.mqtt2 = Mqtt(self.app, config_prefix="MQTT2")
+        self.mqtt3 = Mqtt(self.app, config_prefix="MQTT3")
+        
+        @self.mqtt.on_subscribe()
+        def handle_subscribe(client, userdata, mid_, granted_qos):
+            self.subscribe_handled_mqtt = True
+        
+        @self.mqtt.on_unsubscribe()
+        def handle_unsubscribe(client, userdata, mid_):
+            self.unsubscribe_handled_mqtt = True
+        
+        @self.mqtt2.on_subscribe()
+        def handle_subscribe(client, userdata, mid_, granted_qos):
+            self.subscribe_handled_mqtt2 = True
+        
+        @self.mqtt2.on_unsubscribe()
+        def handle_unsubscribe(client, userdata, mid_):
+            self.unsubscribe_handled_mqtt2 = True
+        
+        @self.mqtt3.on_subscribe()
+        def handle_subscribe(client, userdata, mid_, granted_qos):
+            self.subscribe_handled_mqtt3 = True
+        
+        @self.mqtt3.on_unsubscribe()
+        def handle_unsubscribe(client, userdata, mid_):
+            self.unsubscribe_handled_mqtt3 = True
+
+        ret, _ = self.mqtt.subscribe('mqtt/test')
+        self.assertEqual(ret, MQTT_ERR_SUCCESS)
+        wait()
+        self.assertTrue(self.subscribe_handled_mqtt)
+        ret, _ = self.mqtt.unsubscribe('mqtt/test')
+        self.assertEqual(ret, MQTT_ERR_SUCCESS)
+        wait()
+        self.assertTrue(self.unsubscribe_handled_mqtt)
+        
+        ret, _ = self.mqtt2.subscribe('mqtt2/test')
+        self.assertEqual(ret, MQTT_ERR_SUCCESS)
+        wait()
+        self.assertTrue(self.subscribe_handled_mqtt2)
+        ret, _ = self.mqtt2.unsubscribe('mqtt2/test')
+        self.assertEqual(ret, MQTT_ERR_SUCCESS)
+        wait()
+        self.assertTrue(self.unsubscribe_handled_mqtt2)
+        
+        
+        ret, _ = self.mqtt3.subscribe('mqtt3/test')
+        self.assertEqual(ret, MQTT_ERR_SUCCESS)
+        wait()
+        self.assertTrue(self.subscribe_handled_mqtt3)
+        ret, _ = self.mqtt3.unsubscribe('mqtt3/test')
+        self.assertEqual(ret, MQTT_ERR_SUCCESS)
+        wait()
+        self.assertTrue(self.unsubscribe_handled_mqtt3)
+
+        
+        self.mqtt._disconnect()
+        self.mqtt2._disconnect()
+        self.mqtt3._disconnect()
+        
+    def test_qos_multiple_servers(self):
+        self.mqtt = Mqtt(self.app, config_prefix="MQTT")
+        self.mqtt2 = Mqtt(self.app, config_prefix="MQTT2")
+        self.mqtt3 = Mqtt(self.app, config_prefix="MQTT3")
+
+        #### mqtt server one ####
+        # subscribe to a topic with qos = 1
+        self.mqtt.subscribe('mqtt/test', 1)
+        self.assertEqual(1, len(self.mqtt.topics))
+        self.assertEqual(('mqtt/test', 1), self.mqtt.topics['mqtt/test'])
+
+        # subscribe to same topic, overwrite qos
+        self.mqtt.subscribe('mqtt/test', 2)
+        self.assertEqual(1, len(self.mqtt.topics))
+        self.assertEqual(('mqtt/test', 2), self.mqtt.topics['mqtt/test'])
+
+        # unsubscribe
+        self.mqtt.unsubscribe('mqtt/test')
+        self.assertEqual(0, len(self.mqtt.topics))
+        
+        #### mqtt server two ####
+        # subscribe to a topic with qos = 1
+        self.mqtt2.subscribe('mqtt2/test', 1)
+        self.assertEqual(1, len(self.mqtt2.topics))
+        self.assertEqual(('mqtt2/test', 1), self.mqtt2.topics['mqtt2/test'])
+
+        # subscribe to same topic, overwrite qos
+        self.mqtt2.subscribe('mqtt2/test', 2)
+        self.assertEqual(1, len(self.mqtt2.topics))
+        self.assertEqual(('mqtt2/test', 2), self.mqtt2.topics['mqtt2/test'])
+
+        # unsubscribe
+        self.mqtt2.unsubscribe('mqtt2/test')
+        self.assertEqual(0, len(self.mqtt2.topics))
+        
+        #### mqtt server three ####
+        # subscribe to a topic with qos = 1
+        self.mqtt3.subscribe('mqtt3/test', 1)
+        self.assertEqual(1, len(self.mqtt3.topics))
+        self.assertEqual(('mqtt3/test', 1), self.mqtt3.topics['mqtt3/test'])
+
+        # subscribe to same topic, overwrite qos
+        self.mqtt3.subscribe('mqtt3/test', 2)
+        self.assertEqual(1, len(self.mqtt3.topics))
+        self.assertEqual(('mqtt3/test', 2), self.mqtt3.topics['mqtt3/test'])
+
+        # unsubscribe
+        self.mqtt3.unsubscribe('mqtt3/test')
+        self.assertEqual(0, len(self.mqtt3.topics))
+        
+        self.mqtt._disconnect()
+        self.mqtt2._disconnect()
+        self.mqtt3._disconnect()
+    
+    def test_topic_count_multiple_servers(self):
+        self.mqtt = Mqtt(self.app, config_prefix="MQTT")
+        self.mqtt2 = Mqtt(self.app, config_prefix="MQTT2")
+        self.mqtt3 = Mqtt(self.app, config_prefix="MQTT3")
+        
+        self.mqtt.subscribe('mqtt/test1')
+        self.mqtt.subscribe('mqtt/test2')
+        self.assertEqual(2, len(self.mqtt.topics))
+        self.mqtt.unsubscribe_all()
+        self.assertEqual(0, len(self.mqtt.topics))
+        
+        self.mqtt2.subscribe('mqtt2/test1')
+        self.mqtt2.subscribe('mqtt2/test2')
+        self.assertEqual(2, len(self.mqtt2.topics))
+        self.mqtt2.unsubscribe_all()
+        self.assertEqual(0, len(self.mqtt2.topics))
+        
+        self.mqtt3.subscribe('mqtt3/test1')
+        self.mqtt3.subscribe('mqtt3/test2')
+        self.assertEqual(2, len(self.mqtt3.topics))
+        self.mqtt3.unsubscribe_all()
+        self.assertEqual(0, len(self.mqtt3.topics))
+        
+        self.mqtt._disconnect()
+        self.mqtt2._disconnect()
+        self.mqtt3._disconnect()
+    
+    def test_publish_multiple_servers(self):
+        self.mqtt = Mqtt(self.app, config_prefix="MQTT")
+        self.mqtt2 = Mqtt(self.app, config_prefix="MQTT2")
+        self.mqtt3 = Mqtt(self.app, config_prefix="MQTT3")
+        
+        ###### mqtt server one ######
+        self.handled_message_mqtt = False
+        self.handled_publish_mqtt = False
+    
+        @self.mqtt.on_message()
+        def handle_message(client, userdata, message):
+            self.handled_message_mqtt = True
+
+        @self.mqtt.on_publish()
+        def handle_publish(client, userdata, mid):
+            self.handled_publish_mqtt = True
+
+        self.mqtt.subscribe('mqtt/test')
+        wait()
+        self.mqtt.publish('mqtt/test', 'hello world')
+        wait()
+
+        self.assertTrue(self.handled_message_mqtt)
+        self.assertTrue(self.handled_publish_mqtt)
+        self.mqtt._disconnect()
+        
+        ###### mqtt server two ######
+        self.handled_message_mqtt = False
+        self.handled_publish_mqtt = False
+    
+        @self.mqtt2.on_message()
+        def handle_message(client, userdata, message):
+            self.handled_message_mqtt = True
+
+        @self.mqtt2.on_publish()
+        def handle_publish(client, userdata, mid):
+            self.handled_publish_mqtt = True
+
+        self.mqtt2.subscribe('mqtt2/test')
+        wait()
+        self.mqtt2.publish('mqtt2/test', 'hello world')
+        wait()
+
+        self.assertTrue(self.handled_message_mqtt)
+        self.assertTrue(self.handled_publish_mqtt)
+        self.mqtt2._disconnect()
+        
+        ###### mqtt server two ######
+        self.handled_message_mqtt = False
+        self.handled_publish_mqtt = False
+    
+        @self.mqtt3.on_message()
+        def handle_message(client, userdata, message):
+            self.handled_message_mqtt = True
+
+        @self.mqtt3.on_publish()
+        def handle_publish(client, userdata, mid):
+            self.handled_publish_mqtt = True
+
+        self.mqtt3.subscribe('mqtt3/test')
+        wait()
+        self.mqtt3.publish('mqtt3/test', 'hello world')
+        wait()
+
+        self.assertTrue(self.handled_message_mqtt)
+        self.assertTrue(self.handled_publish_mqtt)
+        self.mqtt3._disconnect()
+
+    def test_logging_multiple_servers(self):
+        self.mqtt = Mqtt(self.app, config_prefix="MQTT")
+        self.mqtt2 = Mqtt(self.app, config_prefix="MQTT2")
+        self.mqtt3 = Mqtt(self.app, config_prefix="MQTT3")
+
+        @self.mqtt.on_log()
+        def handle_logging(client, userdata, level, buf):
+            self.assertIsNotNone(client)
+            self.assertIsNotNone(level)
+            self.assertIsNotNone(buf)
+        
+        @self.mqtt2.on_log()
+        def handle_logging(client, userdata, level, buf):
+            self.assertIsNotNone(client)
+            self.assertIsNotNone(level)
+            self.assertIsNotNone(buf)
+        
+        @self.mqtt3.on_log()
+        def handle_logging(client, userdata, level, buf):
+            self.assertIsNotNone(client)
+            self.assertIsNotNone(level)
+            self.assertIsNotNone(buf)
+
+        self.mqtt.publish('mqtt/test', 'hello mqtt')
+        self.mqtt.publish('mqtt2/test', 'hello mqtt2')
+        self.mqtt.publish('mqtt3/test', 'hello mqtt3')
+    
+        self.mqtt._disconnect()
+        self.mqtt2._disconnect()
+        self.mqtt3._disconnect()
+    
+    def test_disconnect_multiple_servers(self):
+        self.mqtt = Mqtt()
+        self.mqtt2 = Mqtt()
+        self.mqtt3 = Mqtt()
+        self.connected = False
+        
+        ###### mqtt server one ######
+        @self.mqtt.on_connect()
+        def handle_connect(*args, **kwargs):
+            self.connected = True
+
+        @self.mqtt.on_disconnect()
+        def handle_disconnect(*args, **kwargs):
+            self.connected = False
+        
+        self.assertFalse(self.connected)
+        self.mqtt.init_app(self.app)
+        wait()
+        self.assertTrue(self.connected)
+        self.mqtt._disconnect()
+        wait()
+        self.assertFalse(self.connected)
+        
+        ###### mqtt server two ######
+        @self.mqtt2.on_connect()
+        def handle_connect(*args, **kwargs):
+            self.connected = True
+
+        @self.mqtt2.on_disconnect()
+        def handle_disconnect(*args, **kwargs):
+            self.connected = False
+        
+        self.assertFalse(self.connected)
+        self.mqtt2.init_app(self.app, config_prefix="MQTT2")
+        wait()
+        self.assertTrue(self.connected)
+        self.mqtt2._disconnect()
+        wait()
+        self.assertFalse(self.connected)
+        
+        ###### mqtt server one ######
+        @self.mqtt3.on_connect()
+        def handle_connect(*args, **kwargs):
+            self.connected = True
+
+        @self.mqtt3.on_disconnect()
+        def handle_disconnect(*args, **kwargs):
+            self.connected = False
+        
+        self.assertFalse(self.connected)
+        self.mqtt3.init_app(self.app, config_prefix="MQTT3")
+        wait()
+        self.assertTrue(self.connected)
+        self.mqtt3._disconnect()
+        wait()
+        self.assertFalse(self.connected)
+    
+if __name__ == "__main__":
+    unittest.main()
+    


### PR DESCRIPTION
This commit enhances the capability of flask-mqtt to connect to multiple mqtt servers by adding a parameter `config_prefix` to the initialization of `Mqtt` which by default is `"MQTT"`. This will allow users to add multiple mqtt server configurations to `app.config` and talk with multiple brokers in their application. 

This commit also includes a test_multiple_servers.py in the pytest suite. Moreover the DockerFile was also updated to cater to multiple mosquitto brokers (three, on different ports)