### PR TITLE
Return bool for unsubscribe-all()

### DIFF
--- a/flask_mqtt/__init__.py
+++ b/flask_mqtt/__init__.py
@@ -353,11 +353,20 @@ class Mqtt:
         return None
 
     def unsubscribe_all(self) -> None:
-        """Unsubscribe from all topics."""
+        """
+        Unsubscribe from all topics.
+        
+        Returns True if all topics are unsubscribed from self.topics, otherwise False 
+        
+        """
         topics = list(self.topics.keys())
         for topic in topics:
             self.unsubscribe(topic)
-
+        
+        if not len(self.topics):
+            return True
+        return False
+        
     def publish(
         self,
         topic: str,


### PR DESCRIPTION
While looking into https://github.com/stlehmann/Flask-MQTT/issues/102, I noticed that `unsubscribe-all()` does not return any indicator of whether it was successful or not. This PR just adds a bool return which can be used by the user to have safety checks or error logs in case the unsubscribe does not work