### PR TITLE
Setting Mqtt.app on late initialization

### DIFF
--- a/flask_mqtt/__init__.py
+++ b/flask_mqtt/__init__.py
@@ -107,6 +107,9 @@ class Mqtt:
     def init_app(self, app: Flask, config_prefix : str = "MQTT") -> None:
         """Init the Flask-MQTT addon."""
         
+        if self.app is None:
+            self.app = app
+        
         if config_prefix + "_CLIENT_ID" in app.config:
             self.client_id = app.config["MQTT_CLIENT_ID"]
             

--- a/tests/test_flaskmqtt.py
+++ b/tests/test_flaskmqtt.py
@@ -31,7 +31,7 @@ class FlaskMQTTTestCase(unittest.TestCase):
         mqtt = Mqtt(self.app)
         self.assertIsNotNone(mqtt.app)
 
-    def test_late_initialization_app_not_none(self):
+    def test_late_initialization_app_is_not_none(self):
         mqtt = Mqtt()
         mqtt.init_app(self.app)
         self.assertIsNotNone(mqtt.app)

--- a/tests/test_flaskmqtt.py
+++ b/tests/test_flaskmqtt.py
@@ -31,10 +31,10 @@ class FlaskMQTTTestCase(unittest.TestCase):
         mqtt = Mqtt(self.app)
         self.assertIsNotNone(mqtt.app)
 
-    def test_late_initialization_app_is_none(self):
+    def test_late_initialization_app_not_none(self):
         mqtt = Mqtt()
         mqtt.init_app(self.app)
-        self.assertIsNone(mqtt.app)
+        self.assertIsNotNone(mqtt.app)
 
     def test_mqtt_config_values(self):
         self.app.config['MQTT_USERNAME'] = 'username'


### PR DESCRIPTION
Original PR #122 

Changed the failing test case to assert that Mqtt.app is not None at late inicialization.