### PR TITLE
old version variable fix

### DIFF
--- a/flask_mqtt/__init__.py
+++ b/flask_mqtt/__init__.py
@@ -45,7 +45,7 @@ if sys.version_info[0] >= 3:
     unicode = str
 
 # current Flask-MQTT version
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 #: Container for topic + qos
 TopicQos = namedtuple("TopicQos", ["topic", "qos"])


### PR DESCRIPTION
Fixed version variable in __init__.py that was left to '1.1.1' after update to '1.1.2'.