### PR TITLE
fix:'clean_session' in app.config is not passed to the client

### DIFF
--- a/flask_mqtt/__init__.py
+++ b/flask_mqtt/__init__.py
@@ -118,14 +118,14 @@ class Mqtt:
         else:
             self.client._client_id = self.client_id
 
+        if config_prefix + "_CLEAN_SESSION" in app.config:
+            self.clean_session = app.config[config_prefix + "_CLEAN_SESSION"]
+
         self.client._transport = app.config.get(config_prefix + "_TRANSPORT", "tcp").lower()
         self.client._protocol = app.config.get(config_prefix + "_PROTOCOL_VERSION", MQTTv311)
         self.client._clean_session = self.clean_session
         self.client.on_connect = self._handle_connect
         self.client.on_disconnect = self._handle_disconnect
-
-        if config_prefix + "_CLEAN_SESSION" in app.config:
-            self.clean_session = app.config[config_prefix + "_CLEAN_SESSION"]
 
         if config_prefix + "_USERNAME" in app.config:
             self.username = app.config[ config_prefix + "_USERNAME"]

--- a/tests/test_flaskmqtt.py
+++ b/tests/test_flaskmqtt.py
@@ -42,7 +42,7 @@ class FlaskMQTTTestCase(unittest.TestCase):
         self.app.config['MQTT_BROKER_URL'] = 'broker_url'
         self.app.config['MQTT_BROKER_PORT'] = 'broker_port'
         self.app.config['MQTT_TLS_ENABLED'] = 'tls_enabled'
-        self.app.config['MQTT_CLEAN_SESSION'] = True
+        self.app.config['MQTT_CLEAN_SESSION'] = False
         self.app.config['MQTT_KEEPALIVE'] = 'keepalive'
         self.app.config['MQTT_LAST_WILL_TOPIC'] = 'home/lastwill'
         self.app.config['MQTT_LAST_WILL_MESSAGE'] = 'last will'
@@ -63,7 +63,7 @@ class FlaskMQTTTestCase(unittest.TestCase):
         self.assertEqual('broker_url', mqtt.broker_url)
         self.assertEqual('broker_port', mqtt.broker_port)
         self.assertEqual('tls_enabled', mqtt.tls_enabled)
-        self.assertEqual(True, mqtt.clean_session)
+        self.assertEqual(False, mqtt.clean_session)
         self.assertEqual('keepalive', mqtt.keepalive)
         self.assertEqual('home/lastwill', mqtt.last_will_topic)
         self.assertEqual('last will', mqtt.last_will_message)


### PR DESCRIPTION

"app.config['MQTT_CLEAN_SESSION'] = False" does not work currently. The reason is that the param is not passed to "self.client".

The git commit log shows this issue appeared since the commit hashed by "df8fcaae08dd43eb4fd8850f8380e8f8415a00b9".