### PR TITLE
update example .html to use socketio v4.7.5 rather than 1.x

### DIFF
--- a/example/templates/index.html
+++ b/example/templates/index.html
@@ -7,7 +7,7 @@
 
 {% block scripts %}
 {{ super() }}
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/socket.io/1.3.6/socket.io.min.js"></script>
+<script type="text/javascript" src="//cdn.socket.io/4.7.5/socket.io.min.js"></script>
 <script type="text/javascript" charset="utf-8">
   $(document).ready(function() {
     var socket = io.connect('http://' + document.domain + ':' + location.port);


### PR DESCRIPTION
Update the socketio version used in the /example/templates/index.html filr to use version 4 rather than version 1.

Using v1 here gives you an error message and won't work when using recent versions of flask-socketio.

See https://flask-socketio.readthedocs.io/en/latest/intro.html#version-compatibility for js socketio <-> flask-socketio version compatibilities. 

Example works fine for me after the fix. 
