### PR TITLE
Add `mqtt` to Flask App Extensions for Seamless Access

### DIFF
--- a/flask_mqtt/__init__.py
+++ b/flask_mqtt/__init__.py
@@ -109,6 +109,14 @@ class Mqtt:
         
         if self.app is None:
             self.app = app
+
+        if 'mqtt' in app.extensions:
+            raise RuntimeError(
+                "A 'MQTT' instance has already been registered on this Flask app."
+                " Import and use that instance instead."
+            )
+
+        app.extensions['mqtt'] = self
         
         if config_prefix + "_CLIENT_ID" in app.config:
             self.client_id = app.config["MQTT_CLIENT_ID"]


### PR DESCRIPTION
Note: I used Grok 3 to improve & provide a clear PR documentation about my suggested changes.

<hr />

This PR enhances `Flask-MQTT` by registering the MQTT client in the Flask app’s `extensions` dictionary, enabling seamless access to the MQTT instance across the application. It also introduces a safety check to prevent duplicate registrations, ensuring robust integration.

**What I Did:**
- Modified `flask_mqtt/__init__.py` to register the `Mqtt` instance in `app.extensions['mqtt']` during `init_app`.
- Added a guard in `init_app` to raise a `RuntimeError` if an MQTT instance is already registered, preventing accidental overwrites.

**What the Code Does:**
- Stores the `Mqtt` instance in `app.extensions['mqtt']`, making it accessible throughout the Flask app via `current_app.extensions['mqtt']`.
- The safety check ensures that only one MQTT instance is bound to the app, avoiding conflicts or unexpected behavior.

**Why It’s Helpful:**
- **Simplified Access:** Developers can now access the MQTT client anywhere in the app using `current_app.extensions['mqtt'].publish(topic, payload)` (or other methods), aligning with Flask’s extension pattern (e.g., `Flask-SQLAlchemy`, `Flask-SocketIO`). No need to pass the MQTT instance around manually—think of it as giving MQTT a permanent VIP pass to your Flask party.
- **Robustness:** The duplicate registration check prevents subtle bugs, like overwriting an active MQTT connection, saving developers from head-scratching debugging sessions.
- **Consistency:** This brings `Flask-MQTT` in line with Flask’s extension ecosystem, making it more intuitive for Flask developers to adopt and use.

**Example Usage:**
```python
from flask import Flask, current_app
from flask_mqtt import Mqtt

app = Flask(__name__)
app.config['MQTT_BROKER_URL'] = 'broker.hivemq.com'
mqtt = Mqtt()
mqtt.init_app(app)

@app.route('/publish')
def publish_message():
    # Access MQTT client directly from extensions
    current_app.extensions['mqtt'].publish('my/topic', 'Hello, MQTT!')
    return 'Message sent!'
```
This makes your code cleaner and your MQTT integration as smooth as a sunny day.

**Impact:**
This change is backward-compatible and enhances the developer experience by making `Flask-MQTT` more idiomatic and safer to use in larger Flask applications. It’s like giving your MQTT client a cozy home in the Flask mansion, with a guard at the door to keep things orderly.